### PR TITLE
Fix run_exports for libsdformat13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ outputs:
     script: bld_cxx.bat  # [win]
     build:
       run_exports:
-        - {{ pin_subpackage(name, max_pin='x') }}
+        - {{ pin_subpackage(cxx_name, max_pin='x') }}
 
     requirements:
       build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - 1183.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
The `run_exports` was incorrectly declared for `sdformat13` metapackage instead of for the C++ package `libsdformat13`.